### PR TITLE
[feat] support running with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y \
+    git \
+    ffmpeg \
+    unzip \
+    # required for evdev
+    linux-headers-amd64 \
+    gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/HazyResearch/wonderbread.git /app/wonderbread
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -e .
+
+RUN mkdir -p /app/data/demos
+
+WORKDIR /app/data
+RUN gdown 12iJoRZXyBV4pvEsWeAKv2n61LwVbUpqo && \
+    unzip debug_demos.zip && \
+    rm debug_demos.zip && \
+    mv debug_demos/* /app/data/demos && \
+    rm -r debug_demos
+
+WORKDIR /app/wonderbread/benchmark/tasks
+
+ENTRYPOINT ["python3"]
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ docker build -t wonderbread .
 docker run -e OPENAI_API_KEY=<api_key> -it wonderbread documentation/sop_generation/run_experiments.py --model GPT4 --is_debug
 ```
 
+```bash
+# copy the results from the docker container to the host
+docker cp <container_id>:/app/wonderbread/benchmark/tasks/improvement/sop_ranking/outputs/sop_ranking_all_results.csv .
+```
+
 In order to...
 - Record your own workflows, please visit `wonderbread/collect`.
 - Run benchmark tasks, please visit `wonderbread/benchmark/tasks`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ python3 knowledge_transfer/demo_validation/run_experiments.py --model GPT4 --is_
 python3 knowledge_transfer/question_answering/run_experiments.py --model GPT4 --is_debug
 ```
 
+### With Docker
+
+```bash
+# Build Docker image
+docker build -t wonderbread .
+```
+
+```bash
+# Running sop_generation task with GPT4 model
+docker run -e OPENAI_API_KEY=<api_key> -it wonderbread documentation/sop_generation/run_experiments.py --model GPT4 --is_debug
+```
+
 In order to...
 - Record your own workflows, please visit `wonderbread/collect`.
 - Run benchmark tasks, please visit `wonderbread/benchmark/tasks`


### PR DESCRIPTION
# Description

The readme instructions don't provide a method to setup and run the benchmark on a non-mac system. 
- Create docker image with all deps
- Support running and extracting challenge results

Would be nice if some refactoring took place to instead output all results to a result/output folder such that it could be volume mounted
# Results

### Running benchmark
```bash
docker run -e OPENAI_API_KEY=<removed> -it wonderbread improvement/sop_ranking/run_experiments.py --model GPT4 --is_debug
Saving outputs to:  /app/wonderbread/benchmark/tasks/improvement/sop_ranking/outputs
Doing 3 / 3 runs that we haven't done yet.
100%|███████████████████████████████████████████████████████████████████████████████████| 3/3 [00:34<00:00, 11.34s/it]
Saved output CSV to /app/wonderbread/benchmark/tasks/improvement/sop_ranking/outputs/sop_ranking_all_results.csv
```

### Copying results
```bash
~ghub/wonderbread main ····································· 17:13:16 ─╮
❯ docker cp "d39b331adbcb":/app/wonderbread/benchmark/tasks/improvement/sop_ranking/outputs/sop_ranking_all_results.csv .
Successfully copied 17.4kB to /home/gashon/Github/wonderbread/.

~ghub/wonderbread main ?1 ·································· 17:14:06 ─╮
❯ ls                                                               ─╯
 sop_ranking_all_results.csv

~ghub/wonderbread main ?1 ·································· 17:14:08 ─╮
❯ head sop_ranking_all_results.csv                                 ─╯
folder_name,sop,gt_ranking,pred_ranking,spearman_corr,spearman_p_value,kendall_corr,kendall_p_value,ablation--model,demo_name,task_id,ablation
0 @ 2023-12-25-15-10-58,"What is the top-1 best-selling product in 2022?

1. Click on the ""Reports"" button on the far lefthand sidebar. It has an icon which looks like a chart. It should be located directly above the ""Stores"" button and below the ""Content"" button.
2. In the popup menu that appears, click on the ""Bestsellers"" link to go to the ""Bestsellers Report"" page. The link should be located under the ""Products"" section.
3. Locate the field labeled ""Period"" and click on the dropdown menu to reveal our time options.
4. Click on the ""Year"" option to set the reporting period to Year.
5. Click on the ""From"" textbox to focus it. It should be located directly underneath the ""Period"" field.
6. Type in the first day of our desired time period, which in this case is ""01/01/2022""
7. Click on the ""To"" textbox to focus it. It should be located directly underneath the ""From"" field.
```